### PR TITLE
feat: [sc-676262] Use new instead of current

### DIFF
--- a/lib/redis/reliable_queue.rb
+++ b/lib/redis/reliable_queue.rb
@@ -5,7 +5,7 @@ class Redis
       "redis-queue version #{VERSION}"
     end
 
-    def initialize(queue_name: waiting, redis: Redis.current, timeout: 0)
+    def initialize(queue_name: waiting, redis: Redis.new, timeout: 0)
       @waiting = queue_name
       @redis = redis
       @timeout = timeout


### PR DESCRIPTION
because current has been removed in later versions without replacement.

See https://github.com/redis/redis-rb/issues/1064

Dissociating from previous shortcut 662582 and associating with
[sc-676262]